### PR TITLE
Make renderer compatible with Igor (Summer 2022)

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -66,7 +66,7 @@ class renderer_plugin_actionrenderer extends Doku_Renderer_xhtml
     }
 
     /** @inheritDoc */
-    public function header($text, $level, $pos)
+    public function header($text, $level, $pos, $returnonly = false)
     {
         return $this->trigger(__FUNCTION__, func_get_args());
     }


### PR DESCRIPTION
This is to fix the following error when upgrading Dokuwiki in Igor:
```
Warning: Declaration of renderer_plugin_actionrenderer::header($text, $level, $pos) should 
be compatible with Doku_Renderer_xhtml::header($text, $level, $pos, $returnonly = false) 
in /.../dokuwiki/lib/plugins/actionrenderer/renderer.php on line 69
```